### PR TITLE
Fix shell initialization race condition in tmux sessions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-log",
  "tauri-plugin-shell",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,3 +25,4 @@ tauri = { version = "2.10.2", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-shell = "2"
 dirs = "5"
+tokio = { version = "1", features = ["time"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub fn run() {
             commands::tmux::tmux_kill_session,
             commands::tmux::tmux_send_keys,
             commands::tmux::tmux_capture_pane,
+            commands::tmux::tmux_wait_for_ready,
             commands::terminal::open_terminal,
             commands::terminal::open_editor,
             commands::hooks::run_hooks,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -105,6 +105,13 @@ export function tmuxCapturePane(session: string): Promise<string> {
   return invoke<string>("tmux_capture_pane", { session });
 }
 
+export function tmuxWaitForReady(
+  session: string,
+  timeoutMs?: number,
+): Promise<void> {
+  return invoke<void>("tmux_wait_for_ready", { session, timeoutMs });
+}
+
 // --- Hook commands ---
 
 export function runHooks(

--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -8,6 +8,7 @@ import {
   tmuxKillSession,
   tmuxListSessions,
   tmuxSendKeys,
+  tmuxWaitForReady,
   openTerminal,
   runHooks,
 } from "./tauri";
@@ -54,6 +55,7 @@ export async function startTask({
   if (!existingSession) {
     await tmuxCreateSession(identifier, worktree.path);
     try {
+      await tmuxWaitForReady(identifier);
       // 2.5 Run onStart hooks in the worktree directory
       if (onStart && onStart.length > 0) {
         await runHooks(onStart, worktree.path);
@@ -121,6 +123,7 @@ export async function startFreeTask({
   if (!existingSession) {
     await tmuxCreateSession(branchName, worktree.path);
     try {
+      await tmuxWaitForReady(branchName);
       if (onStart && onStart.length > 0) {
         await runHooks(onStart, worktree.path);
       }


### PR DESCRIPTION
## Summary

Fixes #6 — Commands sent to tmux sessions (e.g. `claude`) were getting truncated because `send-keys` fired before the shell finished loading `.zshrc`/mise hooks.

- Use `tmux wait-for` mechanism: the shell signals readiness after init completes, Rust backend blocks (async) until signal arrives
- Session creation spawns `$SHELL -ic 'tmux wait-for -S ready_{name}; exec $SHELL'` so the signal fires only after full shell init
- New `tmux_wait_for_ready` command with 30s default timeout and proper child process cleanup on timeout
- Validate session names to prevent shell injection via crafted identifiers

## Changes

- **`src-tauri/Cargo.toml`** — Add `tokio` (time feature) for async timeout
- **`src-tauri/src/commands/tmux.rs`** — Modify `tmux_create_session` to use wait-for signal; add `tmux_wait_for_ready` command with spawn-based implementation
- **`src-tauri/src/lib.rs`** — Register new command
- **`src/lib/tauri.ts`** — Add `tmuxWaitForReady` TypeScript wrapper
- **`src/lib/workflows.ts`** — Insert `await tmuxWaitForReady()` in `startTask` and `startFreeTask`

## Test plan

- [ ] Start a task on a repo with mise configuration — verify `claude` command executes fully (no truncation)
- [ ] Start a free task — verify same behavior
- [ ] Verify timeout behavior with a very short timeout value
- [ ] Verify session name with special characters is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)