### PR TITLE
Support branch names with slashes in tmux session names

### DIFF
--- a/src-tauri/src/commands/tmux.rs
+++ b/src-tauri/src/commands/tmux.rs
@@ -64,12 +64,16 @@ pub async fn tmux_create_session(
     name: String,
     working_dir: Option<String>,
 ) -> Result<TmuxSession, String> {
-    if !name
+    let name: String = name
         .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-    {
-        return Err(format!("Invalid session name: {name}"));
-    }
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
 
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let signal = format!("ready_{name}");

--- a/src/components/Board/DependencyGraph.tsx
+++ b/src/components/Board/DependencyGraph.tsx
@@ -46,6 +46,7 @@ import {
   H_GAP,
   V_GAP,
 } from "../../lib/graphLayout";
+import { toSessionName } from "../../lib/tmux-utils";
 import type {
   EnrichedTask,
   TmuxSession,
@@ -208,7 +209,7 @@ function DependencyGraphInner({ onProjectsChange }: DependencyGraphProps) {
             worktree: wt,
             repoId: rw.repoId,
             repoPath: rw.repoPath,
-            session: sessionByName.get(wt.branch) ?? null,
+            session: sessionByName.get(toSessionName(wt.branch)) ?? null,
           });
         }
       }
@@ -260,7 +261,7 @@ function DependencyGraphInner({ onProjectsChange }: DependencyGraphProps) {
         prByBranch.get(task.identifier.toLowerCase()) ??
         (wtInfo ? prByBranch.get(wtInfo.worktree.branch.toLowerCase()) : null);
 
-      const sessionName = task.identifier;
+      const sessionName = toSessionName(task.identifier);
       return {
         id: task.id,
         type: "unifiedTask",

--- a/src/components/Board/OrphanTaskCard.tsx
+++ b/src/components/Board/OrphanTaskCard.tsx
@@ -15,6 +15,7 @@ import type { WorktreeInfo, TmuxSession } from "../../types";
 import { useSettingsStore } from "../../stores/settingsStore";
 import { useWorktreeRemove } from "../../hooks/useWorktrees";
 import { tmuxKillSession, openTerminal, openEditor } from "../../lib/tauri";
+import { toSessionName } from "../../lib/tmux-utils";
 import { useQueryClient } from "@tanstack/react-query";
 
 export type OrphanTaskNodeData = {
@@ -66,7 +67,7 @@ export function OrphanTaskCard({ data }: NodeProps<OrphanTaskNodeType>) {
     if (!session) return;
     setKillingSession(true);
     try {
-      await tmuxKillSession(worktree.branch);
+      await tmuxKillSession(toSessionName(worktree.branch));
       queryClient.invalidateQueries({ queryKey: ["tmux", "sessions"] });
     } catch {
       // Session may already be gone
@@ -84,7 +85,7 @@ export function OrphanTaskCard({ data }: NodeProps<OrphanTaskNodeType>) {
 
     // Kill tmux session first if exists
     try {
-      await tmuxKillSession(worktree.branch);
+      await tmuxKillSession(toSessionName(worktree.branch));
     } catch {
       // Session may not exist
     }

--- a/src/components/Layout/ProjectSelector.tsx
+++ b/src/components/Layout/ProjectSelector.tsx
@@ -40,6 +40,7 @@ import type {
 } from "../../types";
 import { useGitHubReviewRequests } from "../../hooks/useGitHub";
 import { useStartFreeTask } from "../../hooks/useStartTask";
+import { toSessionName } from "../../lib/tmux-utils";
 import { WorkspaceSelector } from "./WorkspaceSelector";
 
 interface ProjectSelectorProps {
@@ -582,7 +583,7 @@ function CleanupSection() {
         if (!selected.has(key)) continue;
         // Kill tmux session if one exists for this branch
         try {
-          await tmuxKillSession(sw.worktree.branch);
+          await tmuxKillSession(toSessionName(sw.worktree.branch));
         } catch {
           // Session may not exist
         }

--- a/src/lib/tmux-utils.ts
+++ b/src/lib/tmux-utils.ts
@@ -1,0 +1,4 @@
+/** Sanitize a branch name / identifier into a valid tmux session name. */
+export function toSessionName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "-");
+}


### PR DESCRIPTION
## Summary

- Add `toSessionName()` utility (`src/lib/tmux-utils.ts`) that sanitizes branch names for tmux by replacing invalid characters (like `/`, `.`) with `-`
- Apply sanitization consistently across all tmux session name derivation points: `workflows.ts`, `DependencyGraph.tsx`, `OrphanTaskCard.tsx`, `ProjectSelector.tsx`
- Replace hard validation error in Rust backend (`tmux.rs`) with auto-sanitization as a defensive fallback

## Test plan

- [ ] Create a free task with branch `feature/test-slash` → tmux session should be created as `feature-test-slash`
- [ ] Verify session kill works for branches with slashes (orphan card + stale cleanup)
- [ ] Verify existing branches without slashes still work unchanged
- [ ] `mise run check` passes (TypeScript, lint, format)
- [ ] `mise run rust:check` passes (clippy, fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)