### PR TITLE
Fix onStart hooks running after tmux session creation

### DIFF
--- a/src/lib/workflows.ts
+++ b/src/lib/workflows.ts
@@ -55,13 +55,13 @@ export async function startTask({
   const sessions = await tmuxListSessions();
   const existingSession = sessions.find((s) => s.name === sessionName);
   if (!existingSession) {
+    // Run onStart hooks BEFORE tmux session (e.g. mise trust)
+    if (onStart && onStart.length > 0) {
+      await runHooks(onStart, worktree.path);
+    }
     await tmuxCreateSession(sessionName, worktree.path);
     try {
       await tmuxWaitForReady(sessionName);
-      // 2.5 Run onStart hooks in the worktree directory
-      if (onStart && onStart.length > 0) {
-        await runHooks(onStart, worktree.path);
-      }
       // 3. Launch Claude only on fresh sessions
       const claudeCmd = skill ? `claude "/${skill} ${identifier}"` : "claude";
       await tmuxSendKeys(sessionName, claudeCmd);
@@ -124,12 +124,13 @@ export async function startFreeTask({
   const sessions = await tmuxListSessions();
   const existingSession = sessions.find((s) => s.name === sessionName);
   if (!existingSession) {
+    // Run onStart hooks BEFORE tmux session (e.g. mise trust)
+    if (onStart && onStart.length > 0) {
+      await runHooks(onStart, worktree.path);
+    }
     await tmuxCreateSession(sessionName, worktree.path);
     try {
       await tmuxWaitForReady(sessionName);
-      if (onStart && onStart.length > 0) {
-        await runHooks(onStart, worktree.path);
-      }
       // 3. Launch Claude (plain, no /linear-issue)
       await tmuxSendKeys(sessionName, "claude");
     } catch (err) {


### PR DESCRIPTION
## Summary
- Move `onStart` hooks (e.g. `mise trust`) **before** tmux session creation in both `startTask` and `startFreeTask`
- The tmux shell now starts in an already-configured environment, eliminating mise trust warnings

## Test plan
- [ ] Configure `"onStart": ["mise trust"]` in `directiv.config.json`
- [ ] Start a task from the backlog
- [ ] Verify the tmux shell opens without any mise trust warning
- [ ] Verify Claude launches correctly after the shell is ready

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)